### PR TITLE
chore(deps): update dependency next to v10.0.5

### DIFF
--- a/packages/next-app-with-apollo/package.json
+++ b/packages/next-app-with-apollo/package.json
@@ -25,7 +25,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "react-apollo": "3.1.5",
     "react-dom": "16.13.1",

--- a/packages/next-app-with-auth/package.json
+++ b/packages/next-app-with-auth/package.json
@@ -23,7 +23,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "typescript": "4.0.3"
   },

--- a/packages/next-app-with-emotion/package.json
+++ b/packages/next-app-with-emotion/package.json
@@ -22,7 +22,7 @@
     "@types/react-dom": "16.9.10",
     "emotion": "10.0.27",
     "emotion-theming": "10.0.27",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "typescript": "4.0.3"
   },

--- a/packages/next-app-with-helmet/package.json
+++ b/packages/next-app-with-helmet/package.json
@@ -20,7 +20,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "react-helmet": "6.1.0",
     "typescript": "4.0.3"

--- a/packages/next-app-with-intl/package.json
+++ b/packages/next-app-with-intl/package.json
@@ -23,7 +23,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "react-intl": "5.10.6",
     "typescript": "4.0.3",

--- a/packages/next-app-with-ismobile/package.json
+++ b/packages/next-app-with-ismobile/package.json
@@ -23,7 +23,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "typescript": "4.0.3"
   },

--- a/packages/next-app-with-provider/package.json
+++ b/packages/next-app-with-provider/package.json
@@ -20,7 +20,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "typescript": "4.0.3"
   },

--- a/packages/next-app-with-user/package.json
+++ b/packages/next-app-with-user/package.json
@@ -23,7 +23,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "typescript": "4.0.3"
   },

--- a/packages/next-document-with-emotion/package.json
+++ b/packages/next-document-with-emotion/package.json
@@ -21,7 +21,7 @@
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
     "emotion-server": "10.0.27",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "typescript": "4.0.3"
   },

--- a/packages/next-document-with-helmet/package.json
+++ b/packages/next-document-with-helmet/package.json
@@ -20,7 +20,7 @@
     "@types/node": "14.14.10",
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.10",
-    "next": "9.5.5",
+    "next": "10.0.5",
     "react": "16.13.1",
     "react-helmet": "6.1.0",
     "typescript": "4.0.3"


### PR DESCRIPTION
affects: @atlantis-lab/next-app-with-apollo, @atlantis-lab/next-app-with-auth,
@atlantis-lab/next-app-with-emotion, @atlantis-lab/next-app-with-helmet,
@atlantis-lab/next-app-with-intl, @atlantis-lab/next-app-with-ismobile,
@atlantis-lab/next-app-with-provider, @atlantis-lab/next-app-with-user,
@atlantis-lab/next-document-with-emotion, @atlantis-lab/next-document-with-helmet

ISSUES CLOSED: #123