### PR TITLE
docs: add docs to packages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,13 +4,9 @@ on:
   pull_request:
     types: [closed]
     branches: [master]
-    paths-ignore:
-      - '!**package.json'
-      - '!**yarn.lock'
 
 jobs:
-  run:
-    name: Run
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,12 @@ on:
   pull_request:
     types: [closed]
     branches: [master]
-    paths-ignore:
-      - '!**package.json'
-      - '!**yarn.lock'
 
 jobs:
-  build:
+  publish:
+    needs: check
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 
@@ -37,9 +36,11 @@ jobs:
         run: yarn
 
       - name: Create Release
-        run: yarn lerna version --yes
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          yarn lerna version --no-git-tag-version --yes
+          git add .
+          git commit -m 'chore(release): publish'
+          git push
 
       - name: Config NPM
         uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# Next
+# NextJS Custom Workshop
+
+## [Next App With Apollo](packages/next-app-with-apollo/README.md)
+
+## [Next App With Auth](packages/next-app-with-auth/README.md)
+
+## [Next App With Emotion](packages/next-app-with-emotion/README.md)
+
+## [Next App With Helmet](packages/next-app-with-helmet/README.md)
+
+## [Next App With Intl](packages/next-app-with-intl/README.md)
+
+## [Next App With IsMobile](packages/next-app-with-ismobile/README.md)
+
+## [Next App With Provider](packages/next-app-with-provider/README.md)
+
+## [Next App With User](packages/next-app-with-user/README.md)
+
+## [Next Config With Workspaces](packages/next-config-with-workspaces/README.md)
+
+## [Next Document With Emotion](packages/next-document-with-emotion/README.md)
+
+## [Next Document With Helmet](packages/next-document-with-helmet/README.md)

--- a/packages/next-app-with-apollo/README.md
+++ b/packages/next-app-with-apollo/README.md
@@ -1,1 +1,32 @@
-# app-with-apollo
+# Next App With Apollo
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-apollo
+```
+
+## Example usage
+
+```typescript
+import App            from 'next/app'
+import compose        from 'recompose/compose'
+import { withApollo } from '@atlantis-lab/next-app-with-apollo'
+export const withProviders = compose(
+  withApollo({
+    uri: (process as any).browser
+      ? window.__NEXT_DATA__.props.apolloUrl
+      : process.env.PUBLIC_GATEWAY_URL || 'https://domain.zone/graphql',
+    fetch: (uri, options, props) => {
+      if (props.token) {
+        options.headers.authorization = props.token
+      }
+      if (typeof window !== 'undefined' && window.__NEXT_DATA__.props.token) {
+        options.headers.authorization = window.__NEXT_DATA__.props.token
+      }
+      return fetch(uri, options)
+    },
+  })
+)
+export default withProviders(App)
+```

--- a/packages/next-app-with-auth/README.md
+++ b/packages/next-app-with-auth/README.md
@@ -1,1 +1,17 @@
-# app-with-auth
+# Next App With Auth
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-auth
+```
+
+## Example usage
+
+```typescript
+import App          from 'next/app'
+import compose      from 'recompose/compose'
+import { withAuth } from '@atlantis-lab/next-app-with-auth'
+export const withProviders = compose(withAuth())
+export default withProviders(App)
+```

--- a/packages/next-app-with-emotion/README.md
+++ b/packages/next-app-with-emotion/README.md
@@ -1,1 +1,18 @@
-# app-with-emotion
+# Next App With Emotion
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-emotion
+```
+
+## Example usage
+
+```typescript
+import App                                   from 'next/app'
+import compose                               from 'recompose/compose'
+import { ThemeProvider, injectGlobalStyles } from '@ui/theme'
+import { withEmotion }                       from '@atlantis-lab/next-app-with-emotion'
+export const withProviders = compose(withEmotion({ Provider: ThemeProvider, injectGlobalStyles }))
+export default withProviders(App)
+```

--- a/packages/next-app-with-helmet/README.md
+++ b/packages/next-app-with-helmet/README.md
@@ -1,1 +1,17 @@
-# app-with-helmet
+# Next App With Helmet
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-helmet
+```
+
+## Example usage
+
+```typescript
+import App            from 'next/app'
+import compose        from 'recompose/compose'
+import { withHelmet } from '@atlantis-lab/next-app-with-helmet'
+export const withProviders = compose(withHelmet())
+export default withProviders(App)
+```

--- a/packages/next-app-with-intl/README.md
+++ b/packages/next-app-with-intl/README.md
@@ -1,1 +1,17 @@
-# app-with-intl
+# Next App With Intl
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-intl
+```
+
+## Example usage
+
+```typescript
+import App          from 'next/app'
+import compose      from 'recompose/compose'
+import { withIntl } from '@atlantis-lab/next-app-with-intl'
+export const withProviders = compose(withIntl({ default: 'ru' }))
+export default withProviders(App)
+```

--- a/packages/next-app-with-ismobile/README.md
+++ b/packages/next-app-with-ismobile/README.md
@@ -1,1 +1,17 @@
-# app-with-ismobile
+# Next App With isMobile
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-ismobile
+```
+
+## Example usage
+
+```typescript
+import App              from 'next/app'
+import compose          from 'recompose/compose'
+import { withIsMobile } from '@atlantis-lab/next-app-with-ismobile'
+export const withProviders = compose(withIsMobile())
+export default withProviders(App)
+```

--- a/packages/next-app-with-provider/README.md
+++ b/packages/next-app-with-provider/README.md
@@ -1,1 +1,19 @@
-# app-with-provider
+# Next App With Provider
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-provider
+```
+
+## Example usage
+
+```typescript
+import App                     from 'next/app'
+import compose                 from 'recompose/compose'
+import { StoreProvider }       from '@store/stores'
+import { CookieModalProvider } from '@ui/cookie-modal'
+import { withProvider }        from '@atlantis-lab/next-app-with-provider'
+export const withProviders = compose(withProvider(StoreProvider), withProvider(CookieModalProvider))
+export default withProviders(App)
+```

--- a/packages/next-app-with-user/README.md
+++ b/packages/next-app-with-user/README.md
@@ -1,1 +1,17 @@
-# app-with-user
+# Next App With User
+
+## Install
+
+```
+yarn add @atlantis-lab/next-app-with-user
+```
+
+## Example usage
+
+```typescript
+import App          from 'next/app'
+import compose      from 'recompose/compose'
+import { withUser } from '@atlantis-lab/next-app-with-user'
+export const withProviders = compose(withUser())
+export default withProviders(App)
+```

--- a/packages/next-config-with-workspaces/README.md
+++ b/packages/next-config-with-workspaces/README.md
@@ -1,1 +1,16 @@
-# config-with-workspaces
+# Next Config With Workspaces
+
+## Install
+
+```
+yarn add @atlantis-lab/next-config-with-workspaces
+```
+
+## Example usage
+
+```typescript
+const { withWorkspaces } = require('@atlantis-lab/next-config-with-workspaces')
+const withPlugins = require('next-compose-plugins')
+
+module.exports = withPlugins([withWorkspaces])
+```

--- a/packages/next-document-with-emotion/README.md
+++ b/packages/next-document-with-emotion/README.md
@@ -1,1 +1,17 @@
-# document-with-emotion
+# Next Document With Emotion
+
+## Install
+
+```
+yarn add @atlantis-lab/next-document-with-emotion
+```
+
+## Example usage
+
+```typescript
+import Document        from 'next/document'
+import compose         from 'recompose/compose'
+import { withEmotion } from '@atlantis-lab/next-document-with-emotion'
+const withProviders = compose(withEmotion())
+export default withProviders(Document)
+```

--- a/packages/next-document-with-helmet/README.md
+++ b/packages/next-document-with-helmet/README.md
@@ -1,1 +1,17 @@
-# document-with-helmet
+# Next Document With Helmet
+
+## Install
+
+```
+yarn add @atlantis-lab/next-document-with-helmet
+```
+
+## Example usage
+
+```typescript
+import Document       from 'next/document'
+import compose        from 'recompose/compose'
+import { withHelmet } from '@atlantis-lab/next-document-with-helmet'
+const withProviders = compose(withHelmet())
+export default withProviders(Document)
+```


### PR DESCRIPTION
affects: @atlantis-lab/next-app-with-apollo, @atlantis-lab/next-app-with-auth,
@atlantis-lab/next-app-with-emotion, @atlantis-lab/next-app-with-helmet,
@atlantis-lab/next-app-with-intl, @atlantis-lab/next-app-with-ismobile,
@atlantis-lab/next-app-with-provider, @atlantis-lab/next-app-with-user,
@atlantis-lab/next-config-with-workspaces, @atlantis-lab/next-document-with-emotion,
@atlantis-lab/next-document-with-helmet

also polish workflows