### PR TITLE
feat(next-app-with-intl): add test

### DIFF
--- a/packages/next-app-with-intl/__tests__/with-intl.test.tsx
+++ b/packages/next-app-with-intl/__tests__/with-intl.test.tsx
@@ -1,0 +1,24 @@
+import React         from 'react'
+import TestRenderer  from 'react-test-renderer'
+import { useLocale } from '@atlantis-lab/react-locale'
+import { compose }   from 'recompose'
+
+import { withIntl }  from '../src/index'
+
+describe('test suit for next-app-with-intl', function describer() {
+  test('should wrap the component and provide a locale', function tester() {
+    const withProviders = compose(withIntl({ default: 'en', supported: ['ru', 'en'] }))
+
+    const ContentBlock = () => {
+      const [getCurrent, getSupported] = useLocale()
+
+      return <p>{`${getCurrent} ${getSupported}`}</p>
+    }
+
+    const App = withProviders(ContentBlock)
+
+    const testRenderer = TestRenderer.create(<App messages='Message prop' />)
+
+    expect(testRenderer.root.findByType('p').props.children).toBe('en ru,en')
+  })
+})

--- a/packages/next-app-with-intl/jest.config.ts
+++ b/packages/next-app-with-intl/jest.config.ts
@@ -1,0 +1,3 @@
+const { config } = require('@atlantis-lab/jest-config')
+
+export default config

--- a/packages/next-app-with-intl/package.json
+++ b/packages/next-app-with-intl/package.json
@@ -13,19 +13,26 @@
     "prebuild": "yarn clean",
     "build": "tsc -p tsconfig.json",
     "prepack": "pubflow store",
-    "postpack": "pubflow restore"
+    "postpack": "pubflow restore",
+    "test": "jest"
   },
   "dependencies": {
     "@atlantis-lab/react-locale": "^0.1.2"
   },
   "devDependencies": {
+    "@atlantis-lab/jest-config": "^0.1.2",
     "@monstrs/publish-flow": "0.1.3",
+    "@types/jest": "^26.0.20",
     "@types/node": "14.14.10",
     "@types/react": "16.14.2",
     "@types/react-dom": "16.9.10",
     "next": "10.0.5",
     "react": "16.14.0",
     "react-intl": "5.10.6",
+    "react-test-renderer": "16.14.0",
+    "recompose": "^0.30.0",
+    "ts-jest": "^26.4.4",
+    "ts-node": "^9.1.1",
     "typescript": "4.1.3",
     "universal-cookie": "4.0.4"
   },

--- a/packages/next-app-with-intl/src/with-intl.provider.tsx
+++ b/packages/next-app-with-intl/src/with-intl.provider.tsx
@@ -94,11 +94,11 @@ export const withIntl = ({
       super(props)
 
       this.state = {
-        locale: props.locale,
+        locale: props.locale || defaultLocale,
         messages: props.messages,
       }
 
-      this.store = new LocaleStore(props.locale, supportedLocales)
+      this.store = new LocaleStore(props.locale || defaultLocale, supportedLocales)
     }
 
     onChange = async locale => {


### PR DESCRIPTION
affects: @atlantis-lab/next-app-with-intl

- Also edited `with-intl.provider.tsx` by additionally setting the default value for current locale

ISSUES CLOSED: #139